### PR TITLE
Add frontend env template and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .DS_Store
+
+# Ignore environment files containing secrets
+.env
+.env.*
+!**/*.env.dist

--- a/frontend/.env.dist
+++ b/frontend/.env.dist
@@ -1,0 +1,3 @@
+# Example environment variables for the Next.js frontend
+# Base URL of the API
+NEXT_PUBLIC_API_URL=http://localhost:8080/api

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.dist
 
 # vercel
 .vercel

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,9 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Environment variables
+
+Copy `frontend/.env.dist` to `.env` and adjust the values for your environment. At minimum set `NEXT_PUBLIC_API_URL` to point to the backend API.
+
 ## Getting Started
 
 First, run the development server:

--- a/frontend/components/README.md
+++ b/frontend/components/README.md
@@ -1,0 +1,29 @@
+# UI Components
+
+This directory contains reusable UI components used across the frontend.
+Most elements are based on [shadcn/ui](https://ui.shadcn.com) and are
+located in the `ui` subfolder.
+
+## Available components
+
+- **Button** (`ui/button.tsx`)
+- **Card** (`ui/card.tsx`)
+- **DropdownMenu** (`ui/dropdown-menu.tsx`)
+- **Input** (`ui/input.tsx`)
+- **Label** (`ui/label.tsx`)
+- **NavigationMenu** (`ui/navigation-menu.tsx`)
+- **Select** (`ui/select.tsx`)
+- **Table** (`ui/table.tsx`)
+
+Additional page-specific components live in `app/components`.
+
+## Storybook
+
+A Storybook configuration can be added to document and test components
+interactively. After installing Storybook, run:
+
+```bash
+npm run storybook
+```
+
+to open the component explorer.


### PR DESCRIPTION
## Summary
- ignore .env files globally and allow *.env.dist templates
- whitelist env templates in frontend .gitignore
- document env usage in frontend README
- add sample `.env.dist` for the frontend
- document existing UI components and mention Storybook

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686e7b707bec832fbec1460e23afee90